### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ tater
 
 [![Build Status](https://travis-ci.org/twneale/tater.svg?branch=master)](https://travis-ci.org/twneale/tater)
 [![Coverage Status](https://coveralls.io/repos/twneale/tater/badge.png?branch=master)](https://coveralls.io/r/twneale/tater?branch=master)
-[![Latest Version](https://pypip.in/version/tater/badge.png)](https://pypi.python.org/pypi/tater/)
-[![Download Format](https://pypip.in/format/tater/badge.png)](https://pypi.python.org/pypi/tater/)
+[![Latest Version](https://img.shields.io/pypi/v/tater.svg)](https://pypi.python.org/pypi/tater/)
+[![Download Format](https://img.shields.io/pypi/format/tater.svg)](https://pypi.python.org/pypi/tater/)
 
 A tokenizer and basic "smart objects" AST-building base classes.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tater))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tater`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.